### PR TITLE
fix: switch target to _blank

### DIFF
--- a/frontend/src/components/InternshipBox.tsx
+++ b/frontend/src/components/InternshipBox.tsx
@@ -15,7 +15,7 @@ export function InternshipBox({ internship }: { internship: Internship }) {
           <button
             className="internship-apply-button"
             onClick={() => {
-              window.open(internship.link, "blank");
+              window.open(internship.link, "_blank");
             }}
           >
             Apply


### PR DESCRIPTION
Change target from `blank` to `_blank`, which was causing an error where upon clicking `Apply`, the same tab would always be used.